### PR TITLE
add "project retired" note to readme; install packages with uv; lint with ruff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,18 +9,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - python: '3.7'
-            toxenv: 'py'
-          - python: '3.8'
-            toxenv: 'py'
-          - python: '3.9'
-            toxenv: 'py'
           - python: '3.10'
             toxenv: 'py'
           - python: '3.10'
             toxenv: 'setup'
-          - python: '3.10'
-            toxenv: 'flake8'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,10 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
-        python3 -m pip install --upgrade setuptools pip tox
+        pip install uv
+        uv pip install --system setuptools pip tox
+    - name: linting
+      run: |
+        uvx ruff check
     - name: Test with tox
       run: tox -e ${{ matrix.toxenv }}

--- a/README.md
+++ b/README.md
@@ -5,17 +5,22 @@
 ![Python Version](https://img.shields.io/badge/python-v3.7+-blue)
 
 # Prometheus Raritan PDU Exporter
+
+> **_NOTE:_**  The Prometheus Raritan PDU Exporter project is retired, as
+               Raritan PDUs are able to export Prometheus metrics directly since
+               the firmware update to version 4.0.20 GA.
+
 Python-based Raritan PDU exporter for [prometheus.io](https://prometheus.io/).
 
-This exporter uses the Raritan JSON-RPC API to find inlet, outlet, pole, and 
+This exporter uses the Raritan JSON-RPC API to find inlet, outlet, pole, and
 device sensors to expose their readings to the Prometheus monitoring system.
 
 We have purposely opted not to use the Raritan PDU Python API since direct
 calls to the JSON-RPC API are very straight-forward. Furthermore, only a
-handful of methods are used (`getInlets`, `getOutlets`, `getMetaData`, 
+handful of methods are used (`getInlets`, `getOutlets`, `getMetaData`,
 `getDeviceSlots`, `getDevice`, `getReading` and `getState`) on the `/bulk`
 endpoint, ignoring most of the methods included in the Python API. As a result
-we do not have to bundle the Raritan PDU Python API with this project. 
+we do not have to bundle the Raritan PDU Python API with this project.
 
 ## Installation
 ```commandline
@@ -31,12 +36,12 @@ pip install .
     optional arguments:
       -h, --help            show this help message and exit
       -c config, --config config
-                            configuration json file containing PDU addresses 
+                            configuration json file containing PDU addresses
                             and login info
       -w LISTEN_ADDRESS, --web.listen-address LISTEN_ADDRESS
                             Address and port to listen on (default = :9950)
       -l LOG_LEVEL [LOG_LEVEL ...], --log LOG_LEVEL [LOG_LEVEL ...]
-                            Specify logging level for internal and external 
+                            Specify logging level for internal and external
                             logging, respectively (Default is WARNING,CRITICAL)
 
 ### Example
@@ -45,7 +50,7 @@ pip install .
 raritanpdu --web.listen-address :9950
 ```
 
-The entry points `raritanpdu` and `prometheus_raritan_pdu_exporter` are 
+The entry points `raritanpdu` and `prometheus_raritan_pdu_exporter` are
 identical and can be used interchangeably.
 
 ### Health checks
@@ -61,8 +66,8 @@ platforms to provide a healthcheck that the HTTP server is still successfully
 running and isn't hanging.
 
 ### Debugging
-To enable debugging, set `-l debug` to log debug messages. Note that this will 
-provide a lot of additional information and is therefore not a recommended 
+To enable debugging, set `-l debug` to log debug messages. Note that this will
+provide a lot of additional information and is therefore not a recommended
 setting for long-term use in production.
 
 ### Docker Image
@@ -88,10 +93,10 @@ tox
 ```
 
 ### Testing without VCR cassettes
-Our tests use `vcrpy` to record responses from the Raritan PDU JSON-RPC API, 
-because access to this data is not guaranteed. If you want to test the 
-Raritan PDU Exporter on your PDU setup, copy your `config.json` file to 
-`tests/fixtures/config.json` and remove the `tests/fixtures/vcr_cassettes/` 
-folder and its contents. Tests can then be run as usual, but will take 
-longer as PDUs are requested for data to re-establish the VCR cassettes with 
+Our tests use `vcrpy` to record responses from the Raritan PDU JSON-RPC API,
+because access to this data is not guaranteed. If you want to test the
+Raritan PDU Exporter on your PDU setup, copy your `config.json` file to
+`tests/fixtures/config.json` and remove the `tests/fixtures/vcr_cassettes/`
+folder and its contents. Tests can then be run as usual, but will take
+longer as PDUs are requested for data to re-establish the VCR cassettes with
 data from the PDUs in the config file.


### PR DESCRIPTION
This PR adds a note about the retirement of the project, as the raritan PDUs now export their own metrics.

That said, while being on it, I did still some adjustments:
- bring tooling up-to-date (pip -> uv; flake8 -> ruff)
- remove the tests for python 3.7, 3.8, 3.9 from the tests
- fix whitespace issues in readme